### PR TITLE
Setup static code checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+jobs:
+  check_whitespace:
+    docker:
+      - image: cimg/base:2021.04
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Check for trailing whitespace
+          command: ./dev-scripts/check-trailing-whitespace
+      - run:
+          name: Check that all text files end in a trailing newline
+          command: ./dev-scripts/check-trailing-newline
+  check_bash:
+    docker:
+      - image: koalaman/shellcheck-alpine:v0.8.0
+    steps:
+      - run:
+          name: Install dependencies needed to check out repo
+          command: apk add bash git openssh-client grep
+      - checkout
+      - run:
+          name: Run static analysis on bash scripts
+          command: ./dev-scripts/check-bash
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - check_whitespace
+      - check_bash

--- a/dev-scripts/check-bash
+++ b/dev-scripts/check-bash
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Run static analysis on bash scripts.
+
+# Exit on first failing command.
+set -e
+
+# Exit on unset variable.
+set -u
+
+BASH_SCRIPTS=()
+
+while read -r filepath; do
+  if head -n 1 "${filepath}" | grep --quiet \
+    --regexp '#!/bin/bash' \
+    --regexp '#!/usr/bin/env bash' \
+    --regexp '#!/usr/sh' \
+    --regexp '#!/usr/bin/env sh' \
+    ; then
+      BASH_SCRIPTS+=("${filepath}")
+  fi
+done < <(git ls-files)
+
+readonly BASH_SCRIPTS
+
+if ((${#BASH_SCRIPTS[@]})); then
+  shellcheck "${BASH_SCRIPTS[@]}"
+fi

--- a/dev-scripts/check-trailing-newline
+++ b/dev-scripts/check-trailing-newline
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Verify that all text files end in a trailing newline.
+
+# Exit on first failing command.
+set -e
+
+# Exit on unset variable.
+set -u
+
+# Change directory to repository root.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
+cd "${SCRIPT_DIR}/.."
+
+success=0
+
+while read -r line; do
+  if ! [[ -s "${line}" && -z "$(tail -c 1 "${line}")" ]]; then
+    printf "File must end in a trailing newline: %s\n" "${line}" >&2
+    success=255
+  fi
+done < <(git ls-files \
+  | xargs grep ".*" \
+    --files-with-matches \
+    --binary-files=without-match \
+    --exclude="*third-party*")
+
+exit "${success}"

--- a/dev-scripts/check-trailing-whitespace
+++ b/dev-scripts/check-trailing-whitespace
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Check for trailing whitespace.
+
+# Exit on first failing command.
+set -e
+
+# Exit on unset variable.
+set -u
+
+# Change directory to repository root.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+readonly SCRIPT_DIR
+cd "${SCRIPT_DIR}/.."
+
+while read -r line; do
+  if grep \
+    "\s$" \
+    --line-number \
+    --with-filename \
+    --binary-files=without-match \
+    "${line}"; then
+    echo "ERROR: Found trailing whitespace";
+    exit 1;
+  fi
+done < <(git ls-files)


### PR DESCRIPTION
This PR sets up our usual check scripts, which I want to pull out of https://github.com/tiny-pilot/tinypilot-bundler/pull/1.
I’ve taken everything over from our other repos, except that I had to add one fix in `check-bash`:

```bash
shellcheck "${BASH_SCRIPTS[@]}"
```

This fails if `BASH_SCRIPTS` is empty (which is it right now), so I had to wrap it into a length-check. We could remove this later on, in order to keep all our `check-bash` scripts consistent, but I also don’t see much harm in leaving it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot-bundler/2)
<!-- Reviewable:end -->
