### PR TITLE
Build a bundle on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,17 @@ jobs:
       - run:
           name: Run static analysis on bash scripts
           command: ./dev-scripts/check-bash
+  build_bundle:
+    docker:
+      - image: debian:buster-20220527
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv
+      - run:
+          name: Create the bundle
+          command: ./create-bundle
 
 workflows:
   version: 2
@@ -30,3 +41,4 @@ workflows:
     jobs:
       - check_whitespace
       - check_bash
+      - build_bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
       - run:
           name: Create the bundle
           command: ./create-bundle
-
+      - store_artifacts:
+          path: dist/
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv
+          command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv wget
       - run:
           name: Create the bundle
           command: ./create-bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv
+          command: apt-get update && apt-get install -y git libffi-dev libssl-dev python3-dev python3-venv
       - run:
           name: Create the bundle
           command: ./create-bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get install -y \
   libffi-dev \
   libssl-dev \
   python3-dev \
-  python3-venv
+  python3-venv \
+  wget
 
 WORKDIR /tinypilot-bundler
 COPY ./ .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:buster-20220527
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -10,7 +10,5 @@ RUN apt-get install -y \
 
 WORKDIR /tinypilot-bundler
 COPY ./ .
-
-RUN mkdir -p dist
 
 ENTRYPOINT ["./create-bundle"]

--- a/bundle/install
+++ b/bundle/install
@@ -88,6 +88,9 @@ python3 -m venv venv
 pip install pip==21.3.1
 pip install -r requirements.txt
 
+# TODO: Detect the Debian package version name automatically instead of
+# hardcoding it.
+
 # Run Ansible.
 ansible-playbook \
   --inventory localhost, \

--- a/bundle/install
+++ b/bundle/install
@@ -93,6 +93,7 @@ ansible-playbook \
   --inventory localhost, \
   install.yml \
   --extra-vars "@${INSTALL_SETTINGS_FILE}"
+  --extra-vars "tinypilot_debian_package_path=${PWD}/tinypilot-1.7.1-1-armhf.deb"
 
 # Persist installation settings.
 cp "${INSTALL_SETTINGS_FILE}" "${TINYPILOT_SETTINGS_FILE}"

--- a/bundle/install
+++ b/bundle/install
@@ -88,15 +88,15 @@ python3 -m venv venv
 pip install pip==21.3.1
 pip install -r requirements.txt
 
-# TODO: Detect the Debian package version name automatically instead of
-# hardcoding it.
+TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
+readonly TINYPILOT_DEBIAN_PACKAGE
 
 # Run Ansible.
 ansible-playbook \
   --inventory localhost, \
   install.yml \
   --extra-vars "@${INSTALL_SETTINGS_FILE}" \
-  --extra-vars "tinypilot_debian_package_path=${PWD}/tinypilot-1.7.1-1-armhf.deb"
+  --extra-vars "tinypilot_debian_package_path=${PWD}/${TINYPILOT_DEBIAN_PACKAGE}"
 
 # Persist installation settings.
 cp "${INSTALL_SETTINGS_FILE}" "${TINYPILOT_SETTINGS_FILE}"

--- a/bundle/install
+++ b/bundle/install
@@ -92,7 +92,7 @@ pip install -r requirements.txt
 ansible-playbook \
   --inventory localhost, \
   install.yml \
-  --extra-vars "@${INSTALL_SETTINGS_FILE}"
+  --extra-vars "@${INSTALL_SETTINGS_FILE}" \
   --extra-vars "tinypilot_debian_package_path=${PWD}/tinypilot-1.7.1-1-armhf.deb"
 
 # Persist installation settings.

--- a/bundle/install
+++ b/bundle/install
@@ -22,6 +22,10 @@ readonly INSTALL_SETTINGS_FILE='settings.yml'
 readonly TINYPILOT_SETTINGS_FILE='/home/tinypilot/settings.yml'
 readonly USTREAMER_SETTINGS_FILE='/home/ustreamer/config.yml'
 
+# The filename of the TinyPilot Debian package.
+TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
+readonly TINYPILOT_DEBIAN_PACKAGE
+
 # Prevent installation on the 64-bit version of Raspberry Pi OS.
 # https://github.com/tiny-pilot/tinypilot/issues/929
 if [[ "$(uname -m)" == 'aarch64' && "$(lsb_release --id --short)" == 'Debian' ]]; then
@@ -87,9 +91,6 @@ python3 -m venv venv
 . venv/bin/activate
 pip install pip==21.3.1
 pip install -r requirements.txt
-
-TINYPILOT_DEBIAN_PACKAGE="$(ls tinypilot*.deb)"
-readonly TINYPILOT_DEBIAN_PACKAGE
 
 # Run Ansible.
 ansible-playbook \

--- a/create-bundle
+++ b/create-bundle
@@ -16,7 +16,7 @@ set -x
 #                TinyPilot Pro as well.
 # TODO: Select the latest available version rather than hardcoding a specific
 #       package.
-readonly PKG_URL_TINYPILOT='https://bundles.tinypilotkvm.com/community/tinypilot-1.7.1-1-armhf.deb'
+readonly PKG_URL_TINYPILOT='https://packages.tinypilotkvm.com/community/tinypilot-1.7.1-1-armhf.deb'
 readonly REPO_ANSIBLE_TINYPILOT='https://github.com/tiny-pilot/ansible-role-tinypilot.git'
 readonly REPO_ANSIBLE_NGINX='https://github.com/tiny-pilot/ansible-role-nginx'
 readonly REPO_ANSIBLE_USTREAMER='https://github.com/tiny-pilot/ansible-role-ustreamer'

--- a/create-bundle
+++ b/create-bundle
@@ -22,6 +22,7 @@ readonly REPO_ANSIBLE_NGINX='https://github.com/tiny-pilot/ansible-role-nginx'
 readonly REPO_ANSIBLE_USTREAMER='https://github.com/tiny-pilot/ansible-role-ustreamer'
 
 readonly BUNDLE_DIR='bundle'
+readonly OUTPUT_DIR='dist'
 
 pushd "${BUNDLE_DIR}"
 
@@ -52,9 +53,10 @@ find . \
 popd
 
 # Generate build output.
-ls -lahR "${BUNDLE_DIR}" > dist/files.txt
+mkdir -p "${OUTPUT_DIR}"
+ls -lahR "${BUNDLE_DIR}" > "${OUTPUT_DIR}/files.txt"
 tar \
   --create \
-  --file dist/tinypilot.tar \
+  --file "${OUTPUT_DIR}/tinypilot.tar" \
   --directory "${BUNDLE_DIR}" \
   .

--- a/create-bundle
+++ b/create-bundle
@@ -14,8 +14,10 @@ set -x
 
 # TODO (jotaen): parameterize script to make the installation work for
 #                TinyPilot Pro as well.
-# TODO: Select the latest available version rather than hardcoding a specific
-#       package.
+
+# TODO: Adjust the workflow so that we build Debian packages as part of the same
+# workflow on the same system that we build the bundle so that we don't have to
+# retrieve the Debian package file from a remote URL.
 readonly PKG_URL_TINYPILOT='https://packages.tinypilotkvm.com/community/tinypilot-1.7.1-1-armhf.deb'
 readonly REPO_ANSIBLE_TINYPILOT='https://github.com/tiny-pilot/ansible-role-tinypilot.git'
 readonly REPO_ANSIBLE_NGINX='https://github.com/tiny-pilot/ansible-role-nginx'

--- a/create-bundle
+++ b/create-bundle
@@ -14,12 +14,10 @@ set -x
 
 # TODO (jotaen): parameterize script to make the installation work for
 #                TinyPilot Pro as well.
-readonly REPO_TINYPILOT='https://github.com/tiny-pilot/tinypilot.git'
-readonly REPO_TINYPILOT_BRANCH='master'
+# TODO: Select the latest available version rather than hardcoding a specific
+#       package.
+readonly PKG_URL_TINYPILOT='https://bundles.tinypilotkvm.com/community/tinypilot-1.7.1-1-armhf.deb'
 readonly REPO_ANSIBLE_TINYPILOT='https://github.com/tiny-pilot/ansible-role-tinypilot.git'
-# TODO (jotaen): point this to the main branch again, once the Ansible repo is
-#                properly adjusted to work with this bundler.
-readonly REPO_ANSIBLE_TINYPILOT_BRANCH='experimental/with-bundler'
 readonly REPO_ANSIBLE_NGINX='https://github.com/tiny-pilot/ansible-role-nginx'
 readonly REPO_ANSIBLE_USTREAMER='https://github.com/tiny-pilot/ansible-role-ustreamer'
 
@@ -27,15 +25,12 @@ readonly BUNDLE_DIR='bundle'
 
 pushd "${BUNDLE_DIR}"
 
-git clone \
-  --depth 1 \
-  --branch "${REPO_TINYPILOT_BRANCH}" \
-  "${REPO_TINYPILOT}" tinypilot
+wget "${PKG_URL_TINYPILOT}"
 
 git clone \
   --depth 1 \
-  --branch "${REPO_ANSIBLE_TINYPILOT_BRANCH}" \
-  "${REPO_ANSIBLE_TINYPILOT}" ansible-role-tinypilot
+  --branch master \
+  "${REPO_ANSIBLE_TINYPILOT}"
 
 git clone \
   --depth 1 \


### PR DESCRIPTION
Add a CircleCI config to build a TinyPilot bundle.

This change is part of tiny-pilot/tinypilot#1011 but doesn't address all of its requirements yet.

This change also moves creation of the `dist` output folder to `create-bundle` to avoid duplicating logic between `.circleci/config.yml` and `Dockerfile.

This also tags a more explicit `debian:buster` Docker release to limit the possibility of things breaking due to changes between `debian:buster:latest` images.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/tinypilot-bundler/18)
<!-- Reviewable:end -->
